### PR TITLE
Add shrinking support

### DIFF
--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -147,7 +147,7 @@ exceptions:
     active: true
   SwallowedException:
     active: true
-    ignoredExceptionTypes: 'InterruptedException,NumberFormatException,ParseException,MalformedURLException'
+    ignoredExceptionTypes: 'InterruptedException,NumberFormatException,ParseException,MalformedURLException,SkipEvaluation'
   ThrowingExceptionFromFinally:
     active: true
   ThrowingExceptionInMain:

--- a/evaluator/src/commonMain/kotlin/com/github/jcornaz/kwik/evaluator/Evaluator.kt
+++ b/evaluator/src/commonMain/kotlin/com/github/jcornaz/kwik/evaluator/Evaluator.kt
@@ -36,7 +36,6 @@ fun <T> forAll(
     while (attempts < iterations) {
         val argument = iterator.next()
 
-        @Suppress("SwallowedException") // SkipEvaluation is used to silently skip an evaluation
         val isSatisfied = try {
             context.property(argument).also { ++attempts }
         } catch (skip: SkipEvaluation) {
@@ -44,19 +43,11 @@ fun <T> forAll(
         }
 
         if (!isSatisfied) {
-            val shrinkedArgument = generator.shrink(argument) {
-                try {
-                    context.property(it)
-                } catch (skip: SkipEvaluation) {
-                    true
-                }
-            }
-
             throw FalsifiedPropertyError(
                 attempts,
                 iterations,
                 seed,
-                extractArgumentList(shrinkedArgument)
+                extractArgumentList(generator.shrink(argument, property))
             )
         }
     }

--- a/evaluator/src/commonMain/kotlin/com/github/jcornaz/kwik/evaluator/Evaluator.kt
+++ b/evaluator/src/commonMain/kotlin/com/github/jcornaz/kwik/evaluator/Evaluator.kt
@@ -43,19 +43,28 @@ fun <T> forAll(
             true
         }
 
-        if (!isSatisfied)
+        if (!isSatisfied) {
+            val shrinkedArgument = generator.shrink(argument) {
+                try {
+                    context.property(it)
+                } catch (skip: SkipEvaluation) {
+                    true
+                }
+            }
+
             throw FalsifiedPropertyError(
                 attempts,
                 iterations,
                 seed,
-                extractArgumentList(argument)
+                extractArgumentList(shrinkedArgument)
             )
+        }
     }
 
     println("OK, passed $attempts tests. (seed: $seed)")
 }
 
-private object PropertyEvaluationContextImpl : PropertyEvaluationContext {
+internal object PropertyEvaluationContextImpl : PropertyEvaluationContext {
     override fun skipIf(condition: Boolean) {
         if (condition) throw SkipEvaluation()
     }

--- a/evaluator/src/commonMain/kotlin/com/github/jcornaz/kwik/evaluator/Evaluator.kt
+++ b/evaluator/src/commonMain/kotlin/com/github/jcornaz/kwik/evaluator/Evaluator.kt
@@ -28,7 +28,7 @@ fun <T> forAll(
 ) {
     require(iterations > 0) { "Iterations must be > 0, but was: $iterations" }
 
-    val context = PropertyEvaluationContextImpl
+    val context = SkipExceptionContext
 
     var attempts = 0
     val iterator = generator.testValues(seed).iterator()
@@ -64,13 +64,13 @@ fun <T> forAll(
     println("OK, passed $attempts tests. (seed: $seed)")
 }
 
-internal object PropertyEvaluationContextImpl : PropertyEvaluationContext {
+internal object SkipExceptionContext : PropertyEvaluationContext {
     override fun skipIf(condition: Boolean) {
         if (condition) throw SkipEvaluation()
     }
 }
 
-private class SkipEvaluation : Throwable()
+internal class SkipEvaluation : Throwable()
 
 private fun extractArgumentList(argument: Any?): List<Any?> {
     return if (argument is ArgumentPair<*, *>) {

--- a/evaluator/src/commonMain/kotlin/com/github/jcornaz/kwik/evaluator/Shrinker.kt
+++ b/evaluator/src/commonMain/kotlin/com/github/jcornaz/kwik/evaluator/Shrinker.kt
@@ -4,7 +4,7 @@ import com.github.jcornaz.kwik.generator.api.Generator
 
 internal fun <T> Generator<T>.shrink(initialValue: T, property: PropertyEvaluationContext.(T) -> Boolean): T {
     var lastSkipped: T? = null
-    var skipped = false
+    var hasSkippedValue = false
 
     shrink(initialValue).forEach { value ->
         val evaluation = evaluate(value, property)
@@ -12,14 +12,12 @@ internal fun <T> Generator<T>.shrink(initialValue: T, property: PropertyEvaluati
 
         if (evaluation == null) {
             lastSkipped = value
-            skipped = true
+            hasSkippedValue = true
         }
     }
 
     @Suppress("UNCHECKED_CAST")
-    if (skipped) return shrink(lastSkipped as T, property)
-
-    return initialValue
+    return if (hasSkippedValue) shrink(lastSkipped as T, property) else initialValue
 }
 
 private fun <T> evaluate(value: T, property: PropertyEvaluationContext.(T) -> Boolean): Boolean? {

--- a/evaluator/src/commonMain/kotlin/com/github/jcornaz/kwik/evaluator/Shrinker.kt
+++ b/evaluator/src/commonMain/kotlin/com/github/jcornaz/kwik/evaluator/Shrinker.kt
@@ -2,16 +2,24 @@ package com.github.jcornaz.kwik.evaluator
 
 import com.github.jcornaz.kwik.generator.api.Generator
 
-internal fun <T> Generator<T>.shrink(initialValue: T, property: (T) -> Boolean): T {
+internal fun <T> Generator<T>.shrink(initialValue: T, property: PropertyEvaluationContext.(T) -> Boolean): T {
     var result = initialValue
 
     var smallerValues = shrink(result)
-    var index = smallerValues.indexOfFirst { !property(it) }
+    var index = smallerValues.indexOfFirst { it falsifies property }
     while (index >= 0) {
         result = smallerValues[index]
         smallerValues = shrink(result)
-        index = smallerValues.indexOfFirst { !property(it) }
+        index = smallerValues.indexOfFirst { it falsifies property }
     }
 
     return result
+}
+
+private infix fun <T> T.falsifies(property: PropertyEvaluationContext.(T) -> Boolean): Boolean {
+    return try {
+        !SkipExceptionContext.property(this)
+    } catch (skip: SkipEvaluation) {
+        false
+    }
 }

--- a/evaluator/src/commonMain/kotlin/com/github/jcornaz/kwik/evaluator/Shrinker.kt
+++ b/evaluator/src/commonMain/kotlin/com/github/jcornaz/kwik/evaluator/Shrinker.kt
@@ -1,0 +1,5 @@
+package com.github.jcornaz.kwik.evaluator
+
+import com.github.jcornaz.kwik.generator.api.Generator
+
+internal fun <T> Generator<T>.shrink(initialValue: T, property: (T) -> Boolean): T = initialValue

--- a/evaluator/src/commonMain/kotlin/com/github/jcornaz/kwik/evaluator/Shrinker.kt
+++ b/evaluator/src/commonMain/kotlin/com/github/jcornaz/kwik/evaluator/Shrinker.kt
@@ -2,4 +2,16 @@ package com.github.jcornaz.kwik.evaluator
 
 import com.github.jcornaz.kwik.generator.api.Generator
 
-internal fun <T> Generator<T>.shrink(initialValue: T, property: (T) -> Boolean): T = initialValue
+internal fun <T> Generator<T>.shrink(initialValue: T, property: (T) -> Boolean): T {
+    var result = initialValue
+
+    var smallerValues = shrink(result)
+    var index = smallerValues.indexOfFirst { !property(it) }
+    while (index >= 0) {
+        result = smallerValues[index]
+        smallerValues = shrink(result)
+        index = smallerValues.indexOfFirst { !property(it) }
+    }
+
+    return result
+}

--- a/evaluator/src/commonTest/kotlin/com/github/jcornaz/kwik/evaluator/ForAll1Test.kt
+++ b/evaluator/src/commonTest/kotlin/com/github/jcornaz/kwik/evaluator/ForAll1Test.kt
@@ -100,7 +100,7 @@ class ForAll1Test : AbstractRunnerTest() {
 
             override fun randoms(seed: Long): Sequence<Int> = randomSequence(seed) { it.nextInt() }
 
-            override fun shrink(value: Int): List<Int> = when {
+            override fun shrink(value: Int): Collection<Int> = when {
                 value == 0 -> emptyList()
                 value == -1 || value == 1 -> listOf(0)
                 value < 0 -> listOf(value / 2, value + 1)

--- a/evaluator/src/commonTest/kotlin/com/github/jcornaz/kwik/evaluator/ShrinkerTest.kt
+++ b/evaluator/src/commonTest/kotlin/com/github/jcornaz/kwik/evaluator/ShrinkerTest.kt
@@ -1,0 +1,26 @@
+package com.github.jcornaz.kwik.evaluator
+
+import com.github.jcornaz.kwik.generator.api.Generator
+import com.github.jcornaz.kwik.generator.api.randomSequence
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class ShrinkerTest {
+
+    @Test
+    fun returnsInitialValueIfGeneratorReturnsAnEmptySmallestListOfValue() {
+        val generator = object : Generator<Int> {
+            override val samples: Set<Int> get() = emptySet()
+
+            override fun randoms(seed: Long): Sequence<Int> = randomSequence(seed) { it.nextInt() }
+
+            override fun shrink(value: Int): List<Int> = emptyList()
+        }
+
+        assertEquals(
+            expected = 42,
+            actual = generator.shrink(42) { fail("property should not be evaluated") }
+        )
+    }
+}

--- a/evaluator/src/commonTest/kotlin/com/github/jcornaz/kwik/evaluator/ShrinkerTest.kt
+++ b/evaluator/src/commonTest/kotlin/com/github/jcornaz/kwik/evaluator/ShrinkerTest.kt
@@ -77,7 +77,7 @@ class ShrinkerTest {
     }
 
     @Test
-    fun skipedEvaluationAreIgnored() {
+    fun skippedEvaluationAreIgnored() {
         val generator = shrinker { value ->
             when (value) {
                 0 -> emptyList()

--- a/evaluator/src/commonTest/kotlin/com/github/jcornaz/kwik/evaluator/ShrinkerTest.kt
+++ b/evaluator/src/commonTest/kotlin/com/github/jcornaz/kwik/evaluator/ShrinkerTest.kt
@@ -2,6 +2,7 @@ package com.github.jcornaz.kwik.evaluator
 
 import com.github.jcornaz.kwik.generator.api.Generator
 import com.github.jcornaz.kwik.generator.api.randomSequence
+import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.fail
@@ -10,17 +11,52 @@ class ShrinkerTest {
 
     @Test
     fun returnsInitialValueIfGeneratorReturnsAnEmptySmallestListOfValue() {
-        val generator = object : Generator<Int> {
-            override val samples: Set<Int> get() = emptySet()
+        val generator = shrinker { emptyList() }
 
-            override fun randoms(seed: Long): Sequence<Int> = randomSequence(seed) { it.nextInt() }
+        repeat(100) {
+            val initialValue = Random.nextInt()
+            assertEquals(
+                expected = initialValue,
+                actual = generator.shrink(initialValue) { fail("property should not be evaluated") }
+            )
+        }
+    }
 
-            override fun shrink(value: Int): List<Int> = emptyList()
+    @Test
+    fun returnsInitialValueIfGeneratorReturnsAllPassingValues() {
+        val generator = shrinker { listOf(1, 2, 3, 4) }
+
+        repeat(100) {
+            val initialValue = Random.nextInt()
+            assertEquals(
+                expected = initialValue,
+                actual = generator.shrink(initialValue) { true }
+            )
+        }
+    }
+
+    @Test
+    fun findsTheSmallestFailingValue() {
+        val generator = shrinker { value ->
+            when (value) {
+                0 -> emptyList()
+                1 -> listOf(0)
+                else -> listOf(value / 2, value - 1)
+            }
         }
 
-        assertEquals(
-            expected = 42,
-            actual = generator.shrink(42) { fail("property should not be evaluated") }
-        )
+        repeat(100) {
+            val initialValue = Random.nextInt(2, 1000)
+            val result = generator.shrink(initialValue) { it < 2 }
+            assertEquals(2, result)
+        }
     }
+}
+
+private fun shrinker(shrinkFct: (Int) -> List<Int>): Generator<Int> = object : Generator<Int> {
+    override val samples: Set<Int> get() = emptySet()
+
+    override fun randoms(seed: Long): Sequence<Int> = randomSequence(seed) { it.nextInt() }
+
+    override fun shrink(value: Int): List<Int> = shrinkFct(value)
 }

--- a/evaluator/src/commonTest/kotlin/com/github/jcornaz/kwik/evaluator/ShrinkerTest.kt
+++ b/evaluator/src/commonTest/kotlin/com/github/jcornaz/kwik/evaluator/ShrinkerTest.kt
@@ -5,6 +5,7 @@ import com.github.jcornaz.kwik.generator.api.randomSequence
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.fail
 
 class ShrinkerTest {
@@ -49,6 +50,30 @@ class ShrinkerTest {
             val initialValue = Random.nextInt(2, 1000)
             val result = generator.shrink(initialValue) { it < 2 }
             assertEquals(2, result)
+        }
+    }
+
+    @Test
+    fun returnsOnlyValuesThatFalsifyTheProperty() {
+        val generator = shrinker { value ->
+            println("shrink $value")
+            when {
+                value == 0 -> emptyList()
+                value == -1 -> listOf(0)
+                value == 1 -> listOf(0)
+                value < 0 -> listOf(value / 2, value + 1)
+                else -> listOf(value / 2, value - 1)
+            }
+        }
+
+        repeat(1000) {
+            val property: (Int) -> Boolean = { it % 2 == 0 }
+            var initialValue = Random.nextInt()
+            while (property(initialValue))
+                initialValue = Random.nextInt()
+
+            val result = generator.shrink(initialValue, property)
+            assertFalse(property(result))
         }
     }
 }

--- a/generator/api/src/commonMain/kotlin/com/github/jcornaz/kwik/generator/api/Generator.kt
+++ b/generator/api/src/commonMain/kotlin/com/github/jcornaz/kwik/generator/api/Generator.kt
@@ -10,7 +10,7 @@ interface Generator<T> {
     /**
      * Samples of values that should always be tested
      */
-    val samples: Set<T>
+    val samples: Set<T> get() = emptySet()
 
     /**
      * Returns a sequence of random value.
@@ -30,7 +30,7 @@ interface Generator<T> {
      * Its implementation is optional.
      * If not implemented, the property evaluator will simply not attempt to shrink the value.
      */
-    fun shrink(value: T): List<T> = emptyList()
+    fun shrink(value: T): Collection<T> = emptyList()
 
     companion object {
 

--- a/generator/api/src/commonMain/kotlin/com/github/jcornaz/kwik/generator/api/Generator.kt
+++ b/generator/api/src/commonMain/kotlin/com/github/jcornaz/kwik/generator/api/Generator.kt
@@ -22,6 +22,16 @@ interface Generator<T> {
      */
     fun randoms(seed: Long): Sequence<T>
 
+    /**
+     * Returns *smaller* values than [value].
+     *
+     * Used in the process of finding the smallest input falsifying a property.
+     *
+     * Its implementation is optional.
+     * If not implemented, the property evaluator will simply not attempt to shrink the value.
+     */
+    fun shrink(value: T): List<T> = emptyList()
+
     companion object {
 
         /**

--- a/generator/api/src/commonTest/kotlin/com/github/jcornaz/kwik/generator/api/CombineTest.kt
+++ b/generator/api/src/commonTest/kotlin/com/github/jcornaz/kwik/generator/api/CombineTest.kt
@@ -47,6 +47,16 @@ class CombineTest : AbstractGeneratorTest() {
         assertTrue(gen.randoms(0).take(100).any { (x, y) -> x < 3 && y >= 3 })
         assertTrue(gen.randoms(0).take(100).any { (x, y) -> y < 3 && x >= 3 })
     }
+
+    @Test
+    fun ifNoneOfTheSourceCanBeShrinkedThenCombinationCannotBeShrinkedEither() {
+        val gen = Generator.combine(
+            Generator.create { it.nextInt() },
+            Generator.create { it.nextDouble() }
+        )
+
+        gen.shrink(10 to 8.0).isEmpty()
+    }
 }
 
 class CombineWithTransformTest : AbstractGeneratorTest() {
@@ -100,7 +110,15 @@ class CombineWithTransformTest : AbstractGeneratorTest() {
         assertTrue(gen.randoms(0).take(100).any { (x, y) -> y < 3 && x >= 3 })
     }
 
-    private data class CombinedValues(val x: Int, val y: Double)
+    @Test
+    fun ifNoneOfTheSourceCanBeShrinkedThenCombinationCannotBeShrinkedEither() {
+        val gen = Generator.combine(
+            Generator.create { it.nextInt() },
+            Generator.create { it.nextDouble() }
+        ) { a, b -> CombinedValues(a, b) }
+
+        gen.shrink(CombinedValues(10, 8.0)).isEmpty()
+    }
 }
 
 class CombineWithTest : AbstractGeneratorTest() {
@@ -135,6 +153,15 @@ class CombineWithTest : AbstractGeneratorTest() {
 
         assertTrue(gen.randoms(0).take(100).any { (x, y) -> x < 3 && y !in setOf("one", "two") })
         assertTrue(gen.randoms(0).take(100).any { (x, y) -> y in setOf("one", "two") && x >= 3 })
+    }
+
+
+    @Test
+    fun ifNoneOfTheSourceCanBeShrinkedThenCombinationCannotBeShrinkedEither() {
+        val gen = Generator.create { it.nextInt() }
+            .combineWith(Generator.create { it.nextDouble() })
+
+        gen.shrink(10 to 8.0).isEmpty()
     }
 }
 
@@ -190,5 +217,15 @@ class CombineWithWithTransformTest : AbstractGeneratorTest() {
         assertTrue(gen.randoms(0).take(100).any { (x, y) -> y < 3 && x >= 3 })
     }
 
-    private data class CombinedValues(val x: Int, val y: Double)
+    @Test
+    fun ifNoneOfTheSourceCanBeShrinkedThenCombinationCannotBeShrinkedEither() {
+        val gen = Generator.create { it.nextInt() }
+            .combineWith(Generator.create { it.nextDouble() }) { a, b ->
+                CombinedValues(a, b)
+            }
+
+        gen.shrink(CombinedValues(10, 8.0)).isEmpty()
+    }
 }
+
+private data class CombinedValues(val x: Int, val y: Double)

--- a/generator/api/src/commonTest/kotlin/com/github/jcornaz/kwik/generator/api/CombineTest.kt
+++ b/generator/api/src/commonTest/kotlin/com/github/jcornaz/kwik/generator/api/CombineTest.kt
@@ -1,63 +1,12 @@
 package com.github.jcornaz.kwik.generator.api
 
 import com.github.jcornaz.kwik.generator.test.AbstractGeneratorTest
+import com.github.jcornaz.kwik.generator.test.shouldBeEquivalentTo
+import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-class CombineTest : AbstractGeneratorTest() {
-
-    override val generator: Generator<*> = Generator.combine(
-        Generator.create { it.nextInt() },
-        Generator.create { it.nextDouble() }
-    )
-
-    @Test
-    fun combineTheValues() {
-        assertTrue(generator.randoms(0).take(200).distinct().count() > 190)
-    }
-
-    @Test
-    fun combineDifferentValues() {
-        val gen = Generator.combine(
-            Generator.create { it.nextInt() },
-            Generator.create { it.nextInt() }
-        )
-
-        assertTrue(gen.randoms(123).take(200).count { (a, b) -> a != b } > 150)
-    }
-
-    @Test
-    fun combineSamples() {
-        val gen = Generator.combine(
-            Generator.create { it.nextInt() }.withSamples(1, 2),
-            Generator.create { it.nextInt().toString() }.withSamples("one", "two")
-        )
-
-        assertEquals(setOf(1 to "one", 1 to "two", 2 to "one", 2 to "two"), gen.samples)
-    }
-
-    @Test
-    fun randomValuesContainsSamples() {
-        val gen = Generator.combine(
-            Generator.create { it.nextInt() + 3 }.withSamples(1, 2),
-            Generator.create { it.nextDouble() + 3.0 }.withSamples(1.0, 2.0)
-        )
-
-        assertTrue(gen.randoms(0).take(100).any { (x, y) -> x < 3 && y >= 3 })
-        assertTrue(gen.randoms(0).take(100).any { (x, y) -> y < 3 && x >= 3 })
-    }
-
-    @Test
-    fun ifNoneOfTheSourceCanBeShrinkedThenCombinationCannotBeShrinkedEither() {
-        val gen = Generator.combine(
-            Generator.create { it.nextInt() },
-            Generator.create { it.nextDouble() }
-        )
-
-        gen.shrink(10 to 8.0).isEmpty()
-    }
-}
 
 class CombineWithTransformTest : AbstractGeneratorTest() {
 
@@ -121,47 +70,40 @@ class CombineWithTransformTest : AbstractGeneratorTest() {
     }
 }
 
+class CombineTest : AbstractGeneratorTest() {
+
+    override val generator: Generator<*> = Generator.combine(
+        Generator.create { it.nextInt() },
+        Generator.create { it.nextDouble() }
+    )
+
+    @Test
+    fun isEquivalentToCombineWithTransform() {
+        repeat(100) {
+            val genA = Random.nextIntGenerator()
+            val genB = Random.nextDoubleGenerator()
+
+            Generator.combine(genA, genB)
+                .shouldBeEquivalentTo(Generator.combine(genA, genB) { a, b -> a to b })
+        }
+    }
+}
+
+
 class CombineWithTest : AbstractGeneratorTest() {
 
     override val generator: Generator<*> =
         Generator.create { it.nextInt() }.combineWith(Generator.create { it.nextDouble() })
 
     @Test
-    fun combineTheValues() {
-        assertTrue(generator.randoms(0).take(200).distinct().count() > 190)
-    }
+    fun isEquivalentToCombine() {
+        repeat(100) {
+            val genA = Random.nextIntGenerator()
+            val genB = Random.nextDoubleGenerator()
 
-    @Test
-    fun combineDifferentValues() {
-        val gen = Generator.create { it.nextInt() }.combineWith(Generator.create { it.nextInt() })
-
-        assertTrue(gen.randoms(123).take(200).count { (a, b) -> a != b } > 150)
-    }
-
-    @Test
-    fun combineSamples() {
-        val gen = Generator.create { it.nextInt() }.withSamples(1, 2)
-            .combineWith(Generator.create { it.nextInt().toString() }.withSamples("one", "two"))
-
-        assertEquals(setOf(1 to "one", 1 to "two", 2 to "one", 2 to "two"), gen.samples)
-    }
-
-    @Test
-    fun randomValuesContainsSamples() {
-        val gen = Generator.create { it.nextInt() + 3 }.withSamples(1, 2)
-            .combineWith(Generator.create { it.nextInt().toString() }.withSamples("one", "two"))
-
-        assertTrue(gen.randoms(0).take(100).any { (x, y) -> x < 3 && y !in setOf("one", "two") })
-        assertTrue(gen.randoms(0).take(100).any { (x, y) -> y in setOf("one", "two") && x >= 3 })
-    }
-
-
-    @Test
-    fun ifNoneOfTheSourceCanBeShrinkedThenCombinationCannotBeShrinkedEither() {
-        val gen = Generator.create { it.nextInt() }
-            .combineWith(Generator.create { it.nextDouble() })
-
-        gen.shrink(10 to 8.0).isEmpty()
+            genA.combineWith(genB)
+                .shouldBeEquivalentTo(Generator.combine(genA, genB))
+        }
     }
 }
 
@@ -177,55 +119,64 @@ class CombineWithWithTransformTest : AbstractGeneratorTest() {
             }
 
     @Test
-    fun combineTheValues() {
-        assertTrue(generator.randoms(0).take(200).distinct().count() > 190)
-    }
+    fun isEquivalentToCombineWithTransform() {
+        repeat(100) {
+            val genA = Random.nextIntGenerator()
+            val genB = Random.nextDoubleGenerator()
 
-    @Test
-    fun combineDifferentValues() {
-        val gen = Generator.create { it.nextInt() }
-            .combineWith(Generator.create { it.nextInt() }) { a, b -> a to b }
-
-        assertTrue(gen.randoms(123).take(200).count { (a, b) -> a != b } > 150)
-    }
-
-    @Test
-    fun combineSamples() {
-        val gen = Generator.create { it.nextInt() }.withSamples(1, 2)
-            .combineWith(Generator.create { it.nextDouble() }.withSamples(3.0, 4.0)) { a, b ->
-                CombinedValues(a, b)
-            }
-
-        assertEquals(
-            setOf(
-                CombinedValues(1, 3.0),
-                CombinedValues(1, 4.0),
-                CombinedValues(2, 3.0),
-                CombinedValues(2, 4.0)
-            ), gen.samples
-        )
-    }
-
-    @Test
-    fun randomValuesContainsSamples() {
-        val gen = Generator.create { it.nextInt() + 3 }.withSamples(1, 2)
-            .combineWith(Generator.create { it.nextDouble() + 3.0 }.withSamples(-1.0, -2.0)) { a, b ->
-                CombinedValues(a, b)
-            }
-
-        assertTrue(gen.randoms(0).take(100).any { (x, y) -> x < 3 && y >= 3 })
-        assertTrue(gen.randoms(0).take(100).any { (x, y) -> y < 3 && x >= 3 })
-    }
-
-    @Test
-    fun ifNoneOfTheSourceCanBeShrinkedThenCombinationCannotBeShrinkedEither() {
-        val gen = Generator.create { it.nextInt() }
-            .combineWith(Generator.create { it.nextDouble() }) { a, b ->
-                CombinedValues(a, b)
-            }
-
-        gen.shrink(CombinedValues(10, 8.0)).isEmpty()
+            genA.combineWith(genB) { a, b -> CombinedValues(a, b) }
+                .shouldBeEquivalentTo(Generator.combine(genA, genB) { a, b -> CombinedValues(a, b) })
+        }
     }
 }
 
 private data class CombinedValues(val x: Int, val y: Double)
+
+private fun Random.nextIntGenerator(): Generator<Int> {
+    val samples = List(nextInt(5)) { nextInt() }.toSet()
+
+    val shrinker: (Int) -> Collection<Int> = if (nextBoolean())
+        { _ -> emptyList() }
+    else
+        { value ->
+            when {
+                value == 0 -> emptyList()
+                value == -1 || value == 1 -> listOf(0)
+                value < 0 -> listOf(value / 2, value + 1)
+                else -> listOf(value / 2, value - 1)
+            }
+        }
+
+
+    return object : Generator<Int> {
+        override val samples: Set<Int>
+            get() = samples
+
+        override fun randoms(seed: Long): Sequence<Int> = randomSequence(seed) { it.nextInt() }
+        override fun shrink(value: Int): Collection<Int> = shrinker(value)
+    }
+}
+
+private fun Random.nextDoubleGenerator(): Generator<Double> {
+    val samples = List(nextInt(5)) { nextDouble() }.toSet()
+
+    val shrinker: (Double) -> Collection<Double> = if (nextBoolean())
+        { _ -> emptyList() }
+    else
+        { value ->
+            when {
+                value == 0.0 -> emptyList()
+                value < 0 -> listOf(value / 2.0)
+                else -> listOf(value / 2.0)
+            }
+        }
+
+
+    return object : Generator<Double> {
+        override val samples: Set<Double>
+            get() = samples
+
+        override fun randoms(seed: Long): Sequence<Double> = randomSequence(seed) { it.nextDouble() }
+        override fun shrink(value: Double): Collection<Double> = shrinker(value)
+    }
+}

--- a/generator/test/src/commonMain/kotlin/com/github/jcornaz/kwik/generator/test/AbstractGeneratorTest.kt
+++ b/generator/test/src/commonMain/kotlin/com/github/jcornaz/kwik/generator/test/AbstractGeneratorTest.kt
@@ -29,3 +29,15 @@ abstract class AbstractGeneratorTest {
         assertEquals(100_000, generator.randoms(12).take(100_000).count())
     }
 }
+
+infix fun <T> Generator<T>.shouldBeEquivalentTo(other: Generator<T>) {
+    assertEquals(other.samples, samples)
+
+    repeat(5) {
+        assertEquals(other.randoms(it.toLong()).take(100).toList(), randoms(it.toLong()).take(100).toList())
+    }
+
+    other.randoms(0L).take(5).forEach {
+        assertEquals(other.shrink(it), shrink(it))
+    }
+}


### PR DESCRIPTION
In case `forAll` succeed to falsify a property, it will attempt to shrink the input to find the smallest input falsifying the property, and display that input in the assertion error message.

Note that the generator has to support shrinking for that (by implementing a `shrink(T): List<T>` method.

Shrinking support for existing generators is not part of this PR.

Resolves #5 