### PR TITLE
Updates to trigger github build on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,9 @@ name: Build
 on:
   push:
     branches:
+    - chore/kotlin-native
     - master
     - '*.*'
-    - chore/kotlin-native
 
   pull_request:
     branches: 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,13 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
-
     strategy:
       matrix:
         java: [8, 11, 13]
+        os: [ubuntu-latest,windows-latest]
     
+    runs-on: ${{ matrix.os }}
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches:
     - master
     - '*.*'
+    - chore/kotlin-native
 
   pull_request:
     branches: 


### PR DESCRIPTION
branch is explicitly defined Chore/kotlin native and should be removed.