### PR TITLE
docs: Fix the download link not pointing to the latest version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Kwik
     :target: https://gitter.im/kwik-test/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badg
 
 .. image:: https://api.bintray.com/packages/kwik/stable/kwik/images/download.svg
-    :target: https://bintray.com/kwik/stable/kwik/0.6.0
+    :target: https://bintray.com/kwik/stable/kwik
 
 .. afterBadges
 

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Kwik
     :target: https://gitter.im/kwik-test/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badg
 
 .. image:: https://api.bintray.com/packages/kwik/stable/kwik/images/download.svg
-    :target: https://bintray.com/kwik/stable/kwik/0.5.0
+    :target: https://bintray.com/kwik/stable/kwik/0.6.0
 
 .. afterBadges
 


### PR DESCRIPTION
It's sad JFrog does not have a static URL pointing to the latest version of an artifact.

Even though the API is there to programmatically retrieve the latest version dynamically, it's probably overkill (see https://jfrog.com/knowledge-base/how-to-find-the-latest-artifact-version-based-on-layout/).

Just aligning the version manually here...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jcornaz/kwik/168)
<!-- Reviewable:end -->
