### PR TITLE
docs: Recomands to use the fun interface to create a custom generator

### DIFF
--- a/docs/write-tests.rst
+++ b/docs/write-tests.rst
@@ -97,8 +97,7 @@ Create a custom generator
 But what if we want to test with input types which are not supported by Kwik, like domain-specific ones?
 
 For this we can create a generator by implementing the interface ``Generator``.
-
-But most of the time it may be simpler to call ``Generator.create``:
+And since that interface is a Kotlin ``fun interface``, (aka SAM)  one can create a custom generator like this:
 
 .. literalinclude:: ../example/src/test/kotlin/com/github/jcornaz/kwik/example/PlusOperatorExample.kt
     :language: kotlin
@@ -115,17 +114,15 @@ For enums or finite set of values we can use ``Generator.enum()`` and ``Generato
     :end-before: //endregion
 
 .. note::
-    You may reuse existing operator to build new ones. This can be done by calling ``Genarator.genarate(Random)`` of other
+    You may reuse existing operators to build new ones. This can be done by calling ``Genarator.genarate(Random)`` on other
     operators, or by using the available :ref:`operators <operators>`
 
 Add samples
 -----------
 
-Testing against random value is great. But often some value have more interest to be tested than others.
+Testing against random values is great. But often some values have more interest to be tested than others.
 
 These edge-cases can be added to a generator with the function ``withSamples``.
-
-And since ``null`` and ``NaN`` are two quite common edge-case, there are dedicated ``withNull`` and ``withNaN`` operators.
 
 .. literalinclude:: ../example/src/test/kotlin/com/github/jcornaz/kwik/example/PlusOperatorExample.kt
     :language: kotlin

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile
 
 plugins {
-    kotlin("jvm") version "1.3.61"
+    kotlin("jvm") version "1.4.0"
 }
 
 group = "com.github.jcornaz.kwik"

--- a/example/src/test/kotlin/com/github/jcornaz/kwik/example/PlusOperatorExample.kt
+++ b/example/src/test/kotlin/com/github/jcornaz/kwik/example/PlusOperatorExample.kt
@@ -9,6 +9,7 @@ import com.github.jcornaz.kwik.generator.api.withSamples
 import com.github.jcornaz.kwik.generator.stdlib.doubles
 import com.github.jcornaz.kwik.generator.stdlib.enum
 import com.github.jcornaz.kwik.generator.stdlib.ints
+import com.github.jcornaz.kwik.generator.stdlib.strings
 import com.github.jcornaz.kwik.generator.stdlib.withNaN
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -68,7 +69,7 @@ class PlusOperatorTest {
     }
 
     //region Create a custom generator
-    val customGenerator1 = Generator.create { rng ->
+    val customGenerator1 = Generator { rng ->
         CustomClass(rng.nextInt(), rng.nextInt())
     }
     //endregion
@@ -86,7 +87,8 @@ class PlusOperatorTest {
     //region Add samples
     val generator = Generator.ints().withSamples(13, 42)
 
-    val generatorWithNull = Generator.ints().withNull()
+    // since ``null`` and ``NaN`` are common edge-case, there are dedicated ``withNull`` and ``withNaN`` operators.
+    val generatorWithNull = Generator.strings().withNull()
     val generatorWithNaN = Generator.doubles().withNaN()
     //endregion
 }


### PR DESCRIPTION
instead of the now deprecated `create` factory function.