### PR TITLE
feat: Generators for ranges

### DIFF
--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -45,9 +45,6 @@ potential-bugs:
     excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
   UnsafeCast:
     active: true
-  InvalidRange:
-    active: true
-    excludes: "**/Ranges.kt"
 
 style:
   active: true

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -45,6 +45,9 @@ potential-bugs:
     excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
   UnsafeCast:
     active: true
+  InvalidRange:
+    active: true
+    excludes: "**/Ranges.kt"
 
 style:
   active: true

--- a/docs/generators.rst
+++ b/docs/generators.rst
@@ -106,6 +106,21 @@ Sequences
 
     Note that there is also a ``nonEmptySequences`` alternative
 
+Ranges
+------
+
+``Generator.ranges(elementGen)``
+    Generate ranges. ``elementGen`` can be used to define the generator of the elements.
+
+``Generator.intRanges(elementGen = Generator.ints())``
+    Generates ``ClosedRanged<Int>``. Includes empty and singleton ranges as samples
+
+``Generator.longRanges(elementGen = Generator.longs())``
+    Generates ``ClosedRanged<Long>``. Includes empty and singleton ranges as samples
+
+``Generator.charRanges(elementGen = Generator.characters())``
+    Generates ``ClosedRanged<Char>``. Includes empty and singleton ranges as samples
+
 Enums
 -----
 

--- a/generator/stdlib/src/commonMain/kotlin/com/github/jcornaz/kwik/generator/stdlib/Ranges.kt
+++ b/generator/stdlib/src/commonMain/kotlin/com/github/jcornaz/kwik/generator/stdlib/Ranges.kt
@@ -1,0 +1,53 @@
+@file:Suppress("EmptyRange")
+
+package com.github.jcornaz.kwik.generator.stdlib
+
+import com.github.jcornaz.kwik.generator.api.Generator
+import com.github.jcornaz.kwik.generator.api.withSamples
+
+
+/**
+ * Returns a generator of ClosedRange<T>, which uses the provided Generator for creating start and end elements
+ *
+ * @param <T> The type of the ClosedRange
+ * @param elementGen A generator producing T, which will create the start and end elements of the range
+ */
+fun <T : Comparable<T>> Generator.Companion.ranges(elementGen: Generator<T>): Generator<ClosedRange<T>> =
+    Generator { rng -> elementGen.generate(rng)..elementGen.generate(rng) }
+
+
+/**
+ * Creates a Generator for ClosedRange<Int>, includes samples for empty range and single item range
+ *
+ * @param elementGen A generator producing T, which will create the start and end elements of the range
+ */
+fun Generator.Companion.intRanges(elementGen: Generator<Int> = ints()): Generator<ClosedRange<Int>> =
+    ranges(elementGen).withSamples(
+        1..0,
+        0..0
+    )
+
+
+/**
+ * Creates a Generator for ClosedRange<Char>, includes samples for empty range and single item range
+ *
+ * @param elementGen A generator producing T, which will create the start and end elements of the range
+ */
+fun Generator.Companion.charRanges(elementGen: Generator<Char> = characters()): Generator<ClosedRange<Char>> =
+    ranges(elementGen).withSamples(
+        'B'..'A',
+        'A'..'A'
+    )
+
+
+/**
+ * Creates a Generator for ClosedRange<Long>, includes samples for empty range and single item range
+ *
+ * @param elementGen A generator producing T, which will create the start and end elements of the range
+ */
+fun Generator.Companion.longRanges(elementGen: Generator<Long> = longs()): Generator<ClosedRange<Long>> =
+    ranges(elementGen).withSamples(
+        1L..0L,
+        0L..0L
+    )
+

--- a/generator/stdlib/src/commonMain/kotlin/com/github/jcornaz/kwik/generator/stdlib/Ranges.kt
+++ b/generator/stdlib/src/commonMain/kotlin/com/github/jcornaz/kwik/generator/stdlib/Ranges.kt
@@ -21,6 +21,7 @@ fun <T : Comparable<T>> Generator.Companion.ranges(elementGen: Generator<T>): Ge
  *
  * @param elementGen A generator producing T, which will create the start and end elements of the range
  */
+@Suppress("InvalidRange")
 fun Generator.Companion.intRanges(elementGen: Generator<Int> = ints()): Generator<ClosedRange<Int>> =
     ranges(elementGen).withSamples(
         1..0,
@@ -33,6 +34,7 @@ fun Generator.Companion.intRanges(elementGen: Generator<Int> = ints()): Generato
  *
  * @param elementGen A generator producing T, which will create the start and end elements of the range
  */
+@Suppress("InvalidRange")
 fun Generator.Companion.charRanges(elementGen: Generator<Char> = characters()): Generator<ClosedRange<Char>> =
     ranges(elementGen).withSamples(
         'B'..'A',
@@ -45,6 +47,7 @@ fun Generator.Companion.charRanges(elementGen: Generator<Char> = characters()): 
  *
  * @param elementGen A generator producing T, which will create the start and end elements of the range
  */
+@Suppress("InvalidRange")
 fun Generator.Companion.longRanges(elementGen: Generator<Long> = longs()): Generator<ClosedRange<Long>> =
     ranges(elementGen).withSamples(
         1L..0L,

--- a/generator/stdlib/src/commonTest/kotlin/com/github/jcornaz/kwik/generator/stdlib/RangeGeneratorTest.kt
+++ b/generator/stdlib/src/commonTest/kotlin/com/github/jcornaz/kwik/generator/stdlib/RangeGeneratorTest.kt
@@ -1,0 +1,84 @@
+@file:Suppress("EmptyRange")
+
+package com.github.jcornaz.kwik.generator.stdlib
+
+import com.github.jcornaz.kwik.generator.api.Generator
+import com.github.jcornaz.kwik.generator.api.randomSequence
+import com.github.jcornaz.kwik.generator.test.AbstractGeneratorTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class RangeGeneratorTest : AbstractGeneratorTest() {
+    override val generator = Generator.ranges(Generator.booleans())
+
+    @Test
+    fun `generates all possible ranges`() {
+        // False .. True
+        // False .. False
+        // True .. True
+        // Empty
+
+        assertTrue(
+            generator.randomSequence(0L)
+                .take(100)
+                .distinct()
+                .count() == 4
+        )
+    }
+}
+
+class IntRangeGeneratorTest : AbstractGeneratorTest() {
+
+    override val generator = Generator.intRanges()
+
+    @Test
+    fun `empty range is sampled`() {
+        generator.randomSequence(0L)
+            .take(10)
+            .contains(1..0)
+    }
+
+    @Test
+    fun `single element range is sampled`() {
+        generator.randomSequence(0L)
+            .take(10)
+            .contains(1..1)
+    }
+}
+
+class CharRangeGeneratorTest : AbstractGeneratorTest() {
+    override val generator: Generator<ClosedRange<Char>> = Generator.charRanges()
+
+    @Test
+    fun `empty range is sampled`() {
+        generator.randomSequence(0L)
+            .take(10)
+            .contains('C'..'B')
+    }
+
+    @Test
+    fun `single element range is sampled`() {
+        generator.randomSequence(0L)
+            .take(10)
+            .contains('A'..'A')
+    }
+}
+
+
+class LongRangeGeneratorTest : AbstractGeneratorTest() {
+    override val generator = Generator.longRanges()
+
+    @Test
+    fun `empty range is sampled`() {
+        generator.randomSequence(0L)
+            .take(10)
+            .contains(1L..0L)
+    }
+
+    @Test
+    fun `single element range is sampled`() {
+        generator.randomSequence(0L)
+            .take(10)
+            .contains(1L..1L)
+    }
+}


### PR DESCRIPTION
Adds generators for `ClosedRange<T>`, along with specific signatures for `Char`, `Int` and `Long` which include samples for empty and singleton ranges.

Opening PR as a draft since I want to use the `Generator<Char>` implementation from #215 

I deviated a bit regarding test-naming convention, if you prefer I'll revert it to camelcasing.