### PR TITLE
feat: Generator for LocalDate

### DIFF
--- a/docs/generators.rst
+++ b/docs/generators.rst
@@ -140,7 +140,7 @@ Java Time API
 ``Generator.instants(min: Instant.MIN, max: Instant.MAX)``
     Generates Instants (with nano seconds), includes the samples: ``Instant.EPOCH`` (1970-01-01T00:00:00.000Z), ``min`` and ``max``
 
-``Generator.duration(min, max)``
+``Generator.durations(min, max)``
     Generates Durations (with nano seconds), Includes the samples: ``Duration.ZERO``, ``min`` and ``max``
 
 ``Generator.localTimes(min: LocalTime.MIN, max: LocalTime.MAX)``

--- a/docs/generators.rst
+++ b/docs/generators.rst
@@ -134,3 +134,17 @@ Java
 
 ``Generator.uuids()``
     Create a generator for UUID
+
+Java Time API
+-------------
+``Generator.instants(min: Instant.MIN, max: Instant.MAX)``
+    Generates Instants (with nano seconds), includes the samples: ``Instant.EPOCH`` (1970-01-01T00:00:00.000Z), ``min`` and ``max``
+
+``Generator.duration(min, max)``
+    Generates Durations (with nano seconds), Includes the samples: ``Duration.ZERO``, ``min`` and ``max``
+
+``Generator.localTimes(min: LocalTime.MIN, max: LocalTime.MAX)``
+    Generates LocalTimes (with nano seconds), Includes the samples: ``LocalTime.NOON``, ``min`` and ``max``
+
+``Generator.localDates(min: LocalDate.MIN, max: LocalDate.MAX)``
+    Generates LocalDates, includes the samples: ``LocalDate.EPOCH`` (1970-01-01), ``min`` and ``max``

--- a/generator/stdlib/src/jvmMain/kotlin/com/github/jcornaz/kwik/generator/stdlib/DateTime.kt
+++ b/generator/stdlib/src/jvmMain/kotlin/com/github/jcornaz/kwik/generator/stdlib/DateTime.kt
@@ -119,7 +119,6 @@ fun Generator.Companion.localTimes(
 /**
  * Returns a generator of [LocalDate] between [min] and [max] (inclusive)
  */
-
 fun Generator.Companion.localDates(
     min: LocalDate = LocalDate.MIN,
     max: LocalDate = LocalDate.MAX
@@ -144,4 +143,3 @@ private fun <T> requireMaxEqualOrHigherThanMin(max: Comparable<T>, min: T) {
         "Max must be equal or after min but min was $min and max was $max"
     }
 }
-

--- a/generator/stdlib/src/jvmMain/kotlin/com/github/jcornaz/kwik/generator/stdlib/DateTime.kt
+++ b/generator/stdlib/src/jvmMain/kotlin/com/github/jcornaz/kwik/generator/stdlib/DateTime.kt
@@ -12,6 +12,8 @@ import kotlin.random.Random
 private const val MAX_NANOSECONDS = 999_999_999
 private val MIN_DURATION = Duration.ofSeconds(Long.MIN_VALUE)
 private val MAX_DURATION = Duration.ofSeconds(Long.MAX_VALUE, MAX_NANOSECONDS.toLong())
+private val EPOCH: LocalDate = LocalDate.ofEpochDay(0) // can be replaced by LocalDate.EPOCH with Java 9
+
 
 /**
  * Returns a generator of [Instant] between [min] and [max] (inclusive)
@@ -128,8 +130,8 @@ fun Generator.Companion.localDates(
 
     val samples = mutableListOf(min, max)
 
-    if (LocalDate.EPOCH in range && LocalDate.EPOCH !in samples) {
-        samples += LocalDate.EPOCH
+    if (EPOCH in range && EPOCH !in samples) {
+        samples += EPOCH
     }
 
     return Generator { random: Random ->
@@ -142,3 +144,4 @@ private fun <T> requireMaxEqualOrHigherThanMin(max: Comparable<T>, min: T) {
         "Max must be equal or after min but min was $min and max was $max"
     }
 }
+

--- a/generator/stdlib/src/jvmMain/kotlin/com/github/jcornaz/kwik/generator/stdlib/DateTime.kt
+++ b/generator/stdlib/src/jvmMain/kotlin/com/github/jcornaz/kwik/generator/stdlib/DateTime.kt
@@ -4,6 +4,7 @@ import com.github.jcornaz.kwik.generator.api.Generator
 import com.github.jcornaz.kwik.generator.api.withSamples
 import java.time.Duration
 import java.time.Instant
+import java.time.LocalDate
 import java.time.LocalTime
 import java.time.temporal.ChronoField
 import kotlin.random.Random
@@ -19,9 +20,7 @@ fun Generator.Companion.instants(
     min: Instant = Instant.MIN,
     max: Instant = Instant.MAX
 ): Generator<Instant> {
-    require(max >= min) {
-        "Max must be equal or after min but min was $min and max was $max"
-    }
+    requireMaxEqualOrHigherThanMin(max, min)
 
     val range = min..max
 
@@ -100,9 +99,7 @@ fun Generator.Companion.localTimes(
     min: LocalTime = LocalTime.MIN,
     max: LocalTime = LocalTime.MAX
 ): Generator<LocalTime> {
-    require(max >= min) {
-        "Max must be equal or after min but min was $min and max was $max"
-    }
+    requireMaxEqualOrHigherThanMin(max, min)
 
     val range = min..max
 
@@ -115,4 +112,33 @@ fun Generator.Companion.localTimes(
     return Generator { random: Random ->
         LocalTime.ofNanoOfDay(random.nextLong(min.toNanoOfDay(), max.toNanoOfDay()))
     }.withSamples(samples)
+}
+
+/**
+ * Returns a generator of [LocalDate] between [min] and [max] (inclusive)
+ */
+
+fun Generator.Companion.localDates(
+    min: LocalDate = LocalDate.MIN,
+    max: LocalDate = LocalDate.MAX
+): Generator<LocalDate> {
+    requireMaxEqualOrHigherThanMin(max, min)
+
+    val range = min..max
+
+    val samples = mutableListOf(min, max)
+
+    if (LocalDate.EPOCH in range && LocalDate.EPOCH !in samples) {
+        samples += LocalDate.EPOCH
+    }
+
+    return Generator { random: Random ->
+        LocalDate.ofEpochDay(random.nextLong(min.toEpochDay(), max.toEpochDay()))
+    }.withSamples(samples)
+}
+
+private fun <T> requireMaxEqualOrHigherThanMin(max: Comparable<T>, min: T) {
+    require(max >= min) {
+        "Max must be equal or after min but min was $min and max was $max"
+    }
 }

--- a/generator/stdlib/src/jvmTest/kotlin/com/github/jcornaz/kwik/generator/stdlib/DateTimeGeneratorTest.kt
+++ b/generator/stdlib/src/jvmTest/kotlin/com/github/jcornaz/kwik/generator/stdlib/DateTimeGeneratorTest.kt
@@ -244,7 +244,7 @@ class LocalDateGeneratorTest : AbstractGeneratorTest() {
     }
 
     @Test
-    fun `do not produce value if not in range`() {
+    fun `do not EPOCH value if not in range`() {
         val min = EPOCH.plusDays(2)
         val max = EPOCH.plusWeeks(2)
         assertTrue(Generator.localDates(min = min, max = max).randomSequence(0).take(50).none { it == EPOCH })
@@ -271,7 +271,6 @@ class LocalDateGeneratorTest : AbstractGeneratorTest() {
     fun `generate global max`() {
         assertTrue(Generator.localDates().randomSequence(0).take(50).any { it == LocalDate.MAX })
     }
-
 
     @Test
     fun `generate global min`() {

--- a/generator/stdlib/src/jvmTest/kotlin/com/github/jcornaz/kwik/generator/stdlib/DateTimeGeneratorTest.kt
+++ b/generator/stdlib/src/jvmTest/kotlin/com/github/jcornaz/kwik/generator/stdlib/DateTimeGeneratorTest.kt
@@ -12,7 +12,8 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 private const val MAX_NANOSECONDS = 999_999_999L
-private val EPOCH: LocalDate = LocalDate.ofEpochDay(0) // can be replaced by LocalDate.EPOCH with Java 9
+// can be replaced by LocalDate.EPOCH with Java 9
+private val EPOCH: LocalDate = LocalDate.ofEpochDay(0)
 
 class DurationGeneratorTest : AbstractGeneratorTest() {
     override val generator: Generator<Duration> = Generator.durations(Duration.ZERO, Duration.ofDays(100))

--- a/generator/stdlib/src/jvmTest/kotlin/com/github/jcornaz/kwik/generator/stdlib/DateTimeGeneratorTest.kt
+++ b/generator/stdlib/src/jvmTest/kotlin/com/github/jcornaz/kwik/generator/stdlib/DateTimeGeneratorTest.kt
@@ -3,9 +3,7 @@ package com.github.jcornaz.kwik.generator.stdlib
 import com.github.jcornaz.kwik.generator.api.Generator
 import com.github.jcornaz.kwik.generator.api.randomSequence
 import com.github.jcornaz.kwik.generator.test.AbstractGeneratorTest
-import java.time.Duration
-import java.time.Instant
-import java.time.LocalTime
+import java.time.*
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
@@ -218,5 +216,73 @@ class LocalTimeGeneratorTest : AbstractGeneratorTest() {
     fun generateMin() {
         val min = LocalTime.NOON.plusHours(1)
         assertTrue(Generator.localTimes(min = min).randomSequence(0).take(50).any { it == min })
+    }
+}
+
+
+class LocalDateGeneratorTest : AbstractGeneratorTest() {
+
+    override val generator: Generator<LocalDate> = Generator.localDates()
+
+    @Test
+    fun `fail for invalid range`() {
+        assertFailsWith<IllegalArgumentException> {
+            Generator.localDates(LocalDate.MAX, LocalDate.MIN)
+        }
+    }
+
+
+    @Test
+    fun `produce inside given range`() {
+        val min = LocalDate.EPOCH
+        val max = min.plusWeeks(2)
+        assertTrue(Generator.localDates(min = min, max = max).randomSequence(0).take(50).all { it >= min && it <= max })
+    }
+
+    @Test
+    fun `do not produce value if not in range`() {
+        val min = LocalDate.EPOCH.plusDays(2)
+        val max = LocalDate.EPOCH.plusWeeks(2)
+        assertTrue(Generator.localDates(min = min, max = max).randomSequence(0).take(50).none { it == LocalDate.EPOCH })
+    }
+
+    @Test
+    fun `do not produce global max if not in range`() {
+        val max = LocalDate.MAX.minusDays(1)
+        assertTrue(Generator.localDates(max = max).randomSequence(0).take(50).none { it == LocalDate.MAX })
+    }
+
+    @Test
+    fun `do not produce global min if not in range`() {
+        val min = LocalDate.MIN.plusDays(1)
+        assertTrue(Generator.localDates(min = min).randomSequence(0).take(50).none { it == LocalDate.MIN })
+    }
+
+    @Test
+    fun `generate epoch`() {
+        assertTrue(Generator.localDates().randomSequence(0).take(50).any { it == LocalDate.EPOCH })
+    }
+
+    @Test
+    fun `generate global max`() {
+        assertTrue(Generator.localDates().randomSequence(0).take(50).any { it == LocalDate.MAX })
+    }
+
+
+    @Test
+    fun `generate global min`() {
+        assertTrue(Generator.localDates().randomSequence(0).take(50).any { it == LocalDate.MIN })
+    }
+
+    @Test
+    fun `generate max`() {
+        val max = LocalDate.EPOCH.plusDays(1)
+        assertTrue(Generator.localDates(max = max).randomSequence(0).take(50).any { it == max })
+    }
+
+    @Test
+    fun `generate min`() {
+        val min = LocalDate.EPOCH.plusDays(1)
+        assertTrue(Generator.localDates(min = min).randomSequence(0).take(50).any { it == min })
     }
 }

--- a/generator/stdlib/src/jvmTest/kotlin/com/github/jcornaz/kwik/generator/stdlib/DateTimeGeneratorTest.kt
+++ b/generator/stdlib/src/jvmTest/kotlin/com/github/jcornaz/kwik/generator/stdlib/DateTimeGeneratorTest.kt
@@ -244,7 +244,7 @@ class LocalDateGeneratorTest : AbstractGeneratorTest() {
     }
 
     @Test
-    fun `do not EPOCH value if not in range`() {
+    fun `do not produce EPOCH if not in range`() {
         val min = EPOCH.plusDays(2)
         val max = EPOCH.plusWeeks(2)
         assertTrue(Generator.localDates(min = min, max = max).randomSequence(0).take(50).none { it == EPOCH })

--- a/generator/stdlib/src/jvmTest/kotlin/com/github/jcornaz/kwik/generator/stdlib/DateTimeGeneratorTest.kt
+++ b/generator/stdlib/src/jvmTest/kotlin/com/github/jcornaz/kwik/generator/stdlib/DateTimeGeneratorTest.kt
@@ -3,12 +3,16 @@ package com.github.jcornaz.kwik.generator.stdlib
 import com.github.jcornaz.kwik.generator.api.Generator
 import com.github.jcornaz.kwik.generator.api.randomSequence
 import com.github.jcornaz.kwik.generator.test.AbstractGeneratorTest
-import java.time.*
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 private const val MAX_NANOSECONDS = 999_999_999L
+private val EPOCH: LocalDate = LocalDate.ofEpochDay(0) // can be replaced by LocalDate.EPOCH with Java 9
 
 class DurationGeneratorTest : AbstractGeneratorTest() {
     override val generator: Generator<Duration> = Generator.durations(Duration.ZERO, Duration.ofDays(100))
@@ -231,19 +235,18 @@ class LocalDateGeneratorTest : AbstractGeneratorTest() {
         }
     }
 
-
     @Test
     fun `produce inside given range`() {
-        val min = LocalDate.EPOCH
+        val min = EPOCH
         val max = min.plusWeeks(2)
         assertTrue(Generator.localDates(min = min, max = max).randomSequence(0).take(50).all { it >= min && it <= max })
     }
 
     @Test
     fun `do not produce value if not in range`() {
-        val min = LocalDate.EPOCH.plusDays(2)
-        val max = LocalDate.EPOCH.plusWeeks(2)
-        assertTrue(Generator.localDates(min = min, max = max).randomSequence(0).take(50).none { it == LocalDate.EPOCH })
+        val min = EPOCH.plusDays(2)
+        val max = EPOCH.plusWeeks(2)
+        assertTrue(Generator.localDates(min = min, max = max).randomSequence(0).take(50).none { it == EPOCH })
     }
 
     @Test
@@ -260,7 +263,7 @@ class LocalDateGeneratorTest : AbstractGeneratorTest() {
 
     @Test
     fun `generate epoch`() {
-        assertTrue(Generator.localDates().randomSequence(0).take(50).any { it == LocalDate.EPOCH })
+        assertTrue(Generator.localDates().randomSequence(0).take(50).any { it == EPOCH })
     }
 
     @Test
@@ -276,13 +279,13 @@ class LocalDateGeneratorTest : AbstractGeneratorTest() {
 
     @Test
     fun `generate max`() {
-        val max = LocalDate.EPOCH.plusDays(1)
+        val max = EPOCH.plusDays(1)
         assertTrue(Generator.localDates(max = max).randomSequence(0).take(50).any { it == max })
     }
 
     @Test
     fun `generate min`() {
-        val min = LocalDate.EPOCH.plusDays(1)
+        val min = EPOCH.plusDays(1)
         assertTrue(Generator.localDates(min = min).randomSequence(0).take(50).any { it == min })
     }
 }


### PR DESCRIPTION
- Added LocalDate as supported elements of Java Time Api
- Added documentation for existing Java Time Api elements
- refactored min/max check into separated function to meet detekt's StringLiteralDuplication requirements