### PR TITLE
Revert "build(deps): bump org.jetbrains.kotlin.multiplatform from 1.4.21 to 1.4.21-2"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ import java.util.Date
 
 plugins {
     `maven-publish`
-    id("org.jetbrains.kotlin.multiplatform") version "1.4.21-2"
+    id("org.jetbrains.kotlin.multiplatform") version "1.4.21"
     id("com.github.ben-manes.versions") version "0.36.0"
     id("io.gitlab.arturbosch.detekt") version "1.15.0"
     id("com.jfrog.bintray") version "1.8.5" apply false


### PR DESCRIPTION
According to the change notes to of Kotlin, `kwik` should stay on kotlin`1.4.21`